### PR TITLE
Added support for Enzyme's Mount

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
 var ShallowWrapper = require('enzyme/ShallowWrapper');
+var ReactWrapper = require("enzyme/ReactWrapper");
 
 module.exports = {
   test(val) {
-    return val.constructor && val.constructor.name === ShallowWrapper.name;
+    return (val.constructor && (
+      (val.constructor.name === ShallowWrapper.name)
+      || (val.constructor.name === ReactWrapper.name)
+    );
   },
   print(val, serialize, indent) {
     return val.debug();

--- a/index.js
+++ b/index.js
@@ -3,9 +3,13 @@ var ReactWrapper = require("enzyme/ReactWrapper");
 
 module.exports = {
   test(val) {
-    return (val.constructor && (
-      (val.constructor.name === ShallowWrapper.name)
-      || (val.constructor.name === ReactWrapper.name)
+    // check for val.constructor to exist and if val.constructor.name
+    // equals either the shallow wrapper name OR the react wrapper (mount) name.
+    return (
+      val.constructor && (
+        (val.constructor.name === ShallowWrapper.name)
+        || (val.constructor.name === ReactWrapper.name)
+      )
     );
   },
   print(val, serialize, indent) {

--- a/index.js
+++ b/index.js
@@ -3,14 +3,12 @@ var ReactWrapper = require("enzyme/ReactWrapper");
 
 module.exports = {
   test(val) {
-    // check for val.constructor to exist and if val.constructor.name
-    // equals either the shallow wrapper name OR the react wrapper (mount) name.
-    return (
-      val.constructor && (
-        (val.constructor.name === ShallowWrapper.name)
-        || (val.constructor.name === ReactWrapper.name)
-      )
-    );
+    if (!val || !val.constructor) return false;
+
+    const doesMatch = (val.constructor.name === ShallowWrapper.name)
+      || (val.constructor.name === ReactWrapper.name);
+
+    return doesMatch;
   },
   print(val, serialize, indent) {
     return val.debug();

--- a/test/__snapshots__/mount.test.js.snap
+++ b/test/__snapshots__/mount.test.js.snap
@@ -1,0 +1,30 @@
+exports[`test Serializes components 1`] = `
+<Foo>
+  <div>
+    <span>
+      Hello
+    </span>
+    <Bar text="some text">
+      <h1>
+        some text
+      </h1>
+    </Bar>
+  </div>
+</Foo>
+`;
+
+exports[`test Serializes components that render null 1`] = `<NullComponent />`;
+
+exports[`test Serializes components when using find() 1`] = `
+<span>
+  Hello
+</span>
+`;
+
+exports[`test Serializes components when using find() 2`] = `
+<Bar text="some text">
+  <h1>
+    some text
+  </h1>
+</Bar>
+`;

--- a/test/mount.test.js
+++ b/test/mount.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import serializer from '../';
+
+const Bar = ({ text }) => <h1>{text}</h1>
+
+const Foo = () => (
+  <div>
+    <span>Hello</span>
+    <Bar text="some text" />
+  </div>
+)
+
+it('Serializes components', () => {
+  const wrapper = mount(<Foo />);
+  expect(wrapper).toMatchSnapshot()
+});
+
+it('Serializes components when using find()', () => {
+  const wrapper = mount(<Foo />);
+  expect(wrapper.find('span')).toMatchSnapshot()
+  expect(wrapper.find('Bar')).toMatchSnapshot()
+});
+
+it('Serializes components that render null', () => {
+  const NullComponent = () => null
+  const wrapper = mount(<NullComponent />);
+  expect(wrapper).toMatchSnapshot()
+});


### PR DESCRIPTION
I believe this resolves #8. 

I just added the reference to ReactWrapper and checked if the constructor name matches its name, just like you did for shallowWrapper.

## Output From mountToJson
```
exports[`SmallButton should accept text prop 1`] = `
<SmallButton
  text="See All">
  <button
    className="
      btn btn--small@next
      
      
    "
    style={Object {}}>
    See All
  </button>
</SmallButton>
`;
```

## Output from this solution
```
exports[`SmallButton should accept text prop 1`] = `
<SmallButton text="See All">
  <button className="
      btn btn--small@next
      
      
    " style={{...}} onClick={[undefined]}>
    See All
  </button>
</SmallButton>
`;
```