### PR TITLE
Fix #15: Update enzyme-to-json dependency to v3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Rogelio Guzman",
   "license": "ISC",
   "peerDependency": {
-    "enzyme": "^2.0.0",
+    "enzyme": "^3.0.0",
     "jest": "^17.0.0"
   },
   "repository": {
@@ -31,17 +31,18 @@
     "babel-jest": "^17.0.2",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
-    "enzyme": "^2.6.0",
+    "enzyme": "^3.0.0",
+    "enzyme-adapter-react-16": "^1.0.0",
     "jest": "^17.0.3",
-    "react": "^15.4.1",
+    "react": "^16.0.0",
     "react-addons-test-utils": "^15.4.1",
-    "react-dom": "^15.4.1",
-    "react-test-renderer": "^15.4.1"
+    "react-dom": "^16.0.0",
+    "react-test-renderer": "^16.0.0"
   },
   "scripts": {
     "test": "jest"
   },
   "dependencies": {
-    "enzyme-to-json": "^1.4.4"
+    "enzyme-to-json": "^3.0.1"
   }
 }

--- a/test/__snapshots__/shallow.test.js.snap
+++ b/test/__snapshots__/shallow.test.js.snap
@@ -8,7 +8,7 @@ exports[`test Serializes components 1`] = `
 </div>
 `;
 
-exports[`test Serializes components that render null 1`] = `null`;
+exports[`test Serializes components that render null 1`] = `""`;
 
 exports[`test Serializes components when using find() and dive() 1`] = `
 <span>

--- a/test/mount.test.js
+++ b/test/mount.test.js
@@ -1,29 +1,35 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import Enzyme, { mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 import serializer from '../';
 
-const Bar = ({ text }) => <h1>{text}</h1>
+const adapter = new Adapter();
+
+const Bar = ({ text }) => <h1>{text}</h1>;
 
 const Foo = () => (
   <div>
     <span>Hello</span>
     <Bar text="some text" />
   </div>
-)
+);
 
 it('Serializes components', () => {
+  Enzyme.configure({ adapter });
   const wrapper = mount(<Foo />);
-  expect(wrapper).toMatchSnapshot()
+  expect(wrapper).toMatchSnapshot();
 });
 
 it('Serializes components when using find()', () => {
+  Enzyme.configure({ adapter });
   const wrapper = mount(<Foo />);
-  expect(wrapper.find('span')).toMatchSnapshot()
-  expect(wrapper.find('Bar')).toMatchSnapshot()
+  expect(wrapper.find('span')).toMatchSnapshot();
+  expect(wrapper.find('Bar')).toMatchSnapshot();
 });
 
 it('Serializes components that render null', () => {
-  const NullComponent = () => null
+  Enzyme.configure({ adapter });
+  const NullComponent = () => null;
   const wrapper = mount(<NullComponent />);
-  expect(wrapper).toMatchSnapshot()
+  expect(wrapper).toMatchSnapshot();
 });

--- a/test/shallow.test.js
+++ b/test/shallow.test.js
@@ -1,29 +1,35 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 import serializer from '../';
 
-const Bar = ({ text }) => <h1>{text}</h1>
+const adapter = new Adapter();
+
+const Bar = ({ text }) => <h1>{text}</h1>;
 
 const Foo = () => (
   <div>
     <span>Hello</span>
     <Bar text="some text" />
   </div>
-)
+);
 
 it('Serializes components', () => {
+  Enzyme.configure({ adapter });
   const wrapper = shallow(<Foo />);
-  expect(wrapper).toMatchSnapshot()
+  expect(wrapper).toMatchSnapshot();
 });
 
 it('Serializes components when using find() and dive()', () => {
+  Enzyme.configure({ adapter });
   const wrapper = shallow(<Foo />);
-  expect(wrapper.find('span')).toMatchSnapshot()
-  expect(wrapper.find('Bar').dive()).toMatchSnapshot()
+  expect(wrapper.find('span')).toMatchSnapshot();
+  expect(wrapper.find('Bar').dive()).toMatchSnapshot();
 });
 
 it('Serializes components that render null', () => {
-  const NullComponent = () => null
+  Enzyme.configure({ adapter });
+  const NullComponent = () => null;
   const wrapper = shallow(<NullComponent />);
-  expect(wrapper).toMatchSnapshot()
+  expect(wrapper).toMatchSnapshot();
 });


### PR DESCRIPTION
Not sure this is the correct approach, but it's at least a stab at making it work with the latest version of enzyme-to-json.